### PR TITLE
fixed link content access

### DIFF
--- a/back_end/article.py
+++ b/back_end/article.py
@@ -53,7 +53,12 @@ class ArticleParser:
     
     @property
     def body_text(self):
-        html_text = requests.get(self._link)
+        html_text = requests.get(self._link, allow_redirects=True)
+        print(html_text.url)
+
+        html_text = requests.get(html_text.url, allow_redirects=True)
+        print(html_text.url)
+        
         soup = BeautifulSoup(html_text.content.decode('utf-8'))
         body = soup.find_all('p')
         lists = soup.find_all('li')


### PR DESCRIPTION
RSS links themselves redirect to the real article. Trying to scrape the RSS url results in only scraping the google redirect page, not the actual article. To fix this, you have to follow the redirect twice in order to access the real page. This seems to somewhat slow things down, possibly due to time spent following the redirect, and the increased content to scrape.